### PR TITLE
Set minimum version requirements for "diffusers"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-diffusers
+diffusers>=0.21.0


### PR DESCRIPTION
Lower versions throw ImportErrors because of missing classes in diffusers.image_processor

Example: ImportError: cannot import name 'PipelineImageInput' from 'diffusers.image_processor'